### PR TITLE
Suggestion for link clarity in opening paragraph

### DIFF
--- a/modules/Command-Line-Todo-List/README.md
+++ b/modules/Command-Line-Todo-List/README.md
@@ -1,11 +1,11 @@
 # Command Line Todo List
 
 This benchmark module is the 1st of a series of modules designed to take the
-same problem and make it increasingly more complex as you learn new skills.
+same problem and make it increasingly more complex as you learn new skills. 
+Below are the 2nd and 3rd modules for the Command Line Todo List benchmark. 
 
-1. [Command Line Todo List](../../modules/Command-Line-Todo-List)
-1. [Command Line Todo List With Callbacks](../../modules/Command-Line-Todo-List-With-Callbacks)
-1. [Command Line Todo List With SQL](../../modules/Command-Line-Todo-List-with-SQL)
+2. [Command Line Todo List With Callbacks](../../modules/Command-Line-Todo-List-With-Callbacks)
+2. [Command Line Todo List With SQL](../../modules/Command-Line-Todo-List-with-SQL)
 
 ## Skills
 


### PR DESCRIPTION
Removed the first link to Command Line Todo List that pointed back to the same module. Adjusted intro to reflect this, adjusted numbering of list so 2nd and 3rd modules were accurately numbered.