### PR TITLE
Change exercise description to make it real.

### DIFF
--- a/modules/Movie-Search-CLI/README.md
+++ b/modules/Movie-Search-CLI/README.md
@@ -10,8 +10,7 @@
 ## Exercise
 
 Write a Node.js script called `movie-search.js` that takes a `search term` as
-the first argument, and prints the names of the movies in the console which
-match that search term.
+the first argument, and prints in the console the titles, release years, and title types of the movies in the "Title" section of the page that IMDB displays in response to a search for that term, parenthesizing the years and types as IMDB does.
 
 ### Example usage
 


### PR DESCRIPTION
Existing description asks for "names", even though the IMDB "Name" section is to be disregarded. Example shows more than name of movie is wanted anyway: also year and type. New description is consistent with example and uses IMDB nomenclature.