### PR TITLE
Changed for consistency and updated

### DIFF
--- a/modules/Movie-Search-CLI-With-Promises/README.md
+++ b/modules/Movie-Search-CLI-With-Promises/README.md
@@ -2,7 +2,7 @@
 
 This module is exactly the same as the
 [Movie Search CLI](../Movie-Search-CLI) phase 1 module but with the added
-requirement of the use of Promises.
+requirement of the use of the request-promise or request-promise-native library.
 
 ## Skills
 
@@ -20,4 +20,4 @@ requirement of the use of Promises.
 *These specs are in addition to the specs in the
 [Movie Search CLI](../Movie-Search-CLI) module*
 
-- use the [request-promise](https://github.com/request/request-promise) library to make HTTP requests
+- use the [request-promise](https://github.com/request/request-promise) or [request-promise-native](https://github.com/request/request-promise-native) library to make HTTP requests


### PR DESCRIPTION
Use of promises is not an added requirement. Only the use of a promise-supporting library is. If actual use of promises is an intended requirement, that requirement should be stated and elaborated, since it isn’t obvious (at least to me) how one would benefit from using promises in this context. The proposed change assumes it isn’t an intended requirement. I also propose updating the library requirement to permit using request-promise-native.