### PR TITLE
Update README.md

### DIFF
--- a/modules/Adding-State-to-HTTP/exercises/Remember-Me-App/README.md
+++ b/modules/Adding-State-to-HTTP/exercises/Remember-Me-App/README.md
@@ -7,7 +7,7 @@ cookies to remember the name of visitors to our app.
 
 1. Create an empty directory & repository
 0. Run `npm init -y`
-0. Run `npm install --save express cookie-parser`
+0. Run `npm install --save express body-parser`
 0. Run `npm install --save-dev nodemon`
 0. Put your express app in `app.js`
 0. Start your app with `nodemon app.js`


### PR DESCRIPTION
It seems like we don't need cookie parser to set a cookie (but do need body-parser), just to read it.