### PR TITLE
 change github/issues to guildcrafts/curriculum/issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 
 ## Did you find a bug?
 
-Please submit a [GitHub Issue](https://github.com/isaacs/github/issues/new?&body=%23+Bug+Report%0A%0A)
+Please submit a [GitHub Issue](https://github.com/GuildCrafts/curriculum/issues/new?&body=%23+Bug+Report%0A%0A)
 
 
 ## Did you find a typo or spelling mistake?
@@ -13,4 +13,4 @@ Please submit a [Pull Request](https://github.com/GuildCrafts/curriculum/pulls)
 
 ## Do you want to request a new feature?
 
-Please submit a [GitHub Issue](https://github.com/isaacs/github/issues/new?&body=%23+Feature+Request%0A%0A)
+Please submit a [GitHub Issue](https://github.com/GuildCrafts/curriculum/issues/new?&body=%23+Feature+Request%0A%0A)


### PR DESCRIPTION
fixes links so that learners submit issues to the LG curriculum repo instead of github issues