### PR TITLE
Fix bug in link parsing

### DIFF
--- a/modules/Adding-State-to-HTTP/README.md
+++ b/modules/Adding-State-to-HTTP/README.md
@@ -30,7 +30,7 @@ cookie based authentication
 
 ### Read
 
-- https://en.wikipedia.org/wiki/State_(computer_science)
+- [State (computer science)](https://en.wikipedia.org/wiki/State_(computer_science))
 - [All You Ever Wanted to Know About Sessions In Node.js](https://stormpath.com/blog/everything-you-ever-wanted-to-know-about-node-dot-js-sessions)
 
 


### PR DESCRIPTION
Chrome omits the final parenthesis from its interpretation of the link. This is an attempt to correct that.