### PR TITLE
Delete immature exercise

### DIFF
--- a/modules/Adding-State-to-HTTP/README.md
+++ b/modules/Adding-State-to-HTTP/README.md
@@ -37,5 +37,4 @@ cookie based authentication
 
 ## Exercises
 
-- [Remember Me App](./exercises/Remember-Me-App)
 - [Secure Session Cookie](./exercises/Secure-Session-Cookie)


### PR DESCRIPTION
The Remember Me App exercise does not seem ready yet for prime time, and also does not seem to add anything to the well-developed Secure Session Cookie exercise. In the Remember Me App exercise, as currently formulated: (1) Step 5 references “your Express app” without any prior indication that such an app exists or what it does; (2) Step 7 says to open a terminal window but nothing there or later says what that window is used for; Step 8 refers to “the homepage”, with no prior indication that such a page exists or how to access it; nothing is said about what the response to a form submittal should be, other than the setting of a cookie.