### PR TITLE
Changed instructions for encryption/decryption.

### DIFF
--- a/modules/Adding-State-to-HTTP/exercises/Secure-Session-Cookie/README.md
+++ b/modules/Adding-State-to-HTTP/exercises/Secure-Session-Cookie/README.md
@@ -114,9 +114,11 @@ Build a middleware that serializes a session object into a session cookie using 
 
 ## App 4 - A secure session
 
-Encrypt the session cookie using bcrypt.
+Encrypt and decrypt the session cookie with `cryptr` or another ecryption tool of your choice. If you want the encrypted cookies to be usable after you terminate and restart the application, choose a method that you consider secure enough for using a persistently stored encryption key, and document in the `README.md` file whatever the person installing the application needs to do to choose and persistently store a key.
 
+### Resources
 
+- [Environment Variables Considered Harmful for Your Secrets](http://movingfast.io/articles/environment-variables-considered-harmful/)
 
 ### Specs
 


### PR DESCRIPTION
bcrypt cannot do what this exercise requires. It only hashes and checks strings. It does not encrypt and decrypt them. The proposed new instructions and associated resource appear to be appropriate for this exercise.