### PR TITLE
Installfest update

### DIFF
--- a/modules/Installfest/README.md
+++ b/modules/Installfest/README.md
@@ -60,3 +60,13 @@ install postgresql via homebrew
 - https://www.youtube.com/results?search_query=os+x+homebrew
 - https://www.howtogeek.com/211541/homebrew-for-os-x-easily-installs-desktop-apps-and-terminal-utilities/
 - https://github.com/GuildCrafts/Installapalooza
+
+### Links to Packages for Reference
+- [Caffeine](http://lightheadsw.com/caffeine/)
+- [Dash](https://kapeli.com/dash)
+- [Growl Notify](http://growl.info/)
+- [Slack](https://slack.com/)
+- [ScreenHero](https://screenhero.com/)
+- [Spectacle](https://www.spectacleapp.com/)
+- [Postman](https://www.getpostman.com/)
+- [Xcode](https://developer.apple.com/xcode/)

--- a/modules/Installfest/README.md
+++ b/modules/Installfest/README.md
@@ -39,9 +39,10 @@ slack
 screenhero
 spectacle
 postman
-copyclip
 xcode command line tools
 ```
+
+We would also recommend installing [copyclip](https://itunes.apple.com/us/app/copyclip-clipboard-history-manager/id595191960?mt=12) through the mac app store.
 
 ## Search Terms
 


### PR DESCRIPTION
added links to installfest readme. 
also copyclip can't be installed with homebrew.