### PR TITLE
Remove HTTP requests from JS in the Browser

### DIFF
--- a/modules/JavaScript-in-the-Browser/README.md
+++ b/modules/JavaScript-in-the-Browser/README.md
@@ -4,7 +4,6 @@
 
 - Can avoid defining global variables in Browser JavaScript
 - Can bind to a DOM event in the Browser
-- Can make HTTP requests from JavaScript in the Browser
 - Can describe `DOM event bubbling` in the Browser
 - Can describe what an HTML `<script>` tag does
 - Can describe what the `window` variable is within JavaScript in the Browser


### PR DESCRIPTION
"Can make HTTP requests from JavaScript in the Browser" should be removed from this page and in the list of all skills.

There is a module that goes over making HTTP requests from JavaScript in the browser: https://curriculum.learnersguild.org/modules/HTTP-Requests-From-JavaScript-In-The-Browser/ Within this module, there is another checkbox for a similar skill: "Can make an HTTP request from the browser"