### PR TITLE
References to .bashrc were changed to .bash_profile

### DIFF
--- a/modules/Foundational-Programming-in-Node/exercises/add-node_modules-bin-to-your-path/README.md
+++ b/modules/Foundational-Programming-in-Node/exercises/add-node_modules-bin-to-your-path/README.md
@@ -4,8 +4,8 @@ When we install node modules with executable commands, like `mocha` or `babel`
 we want to be able to simply run `mocha` as apposed to `./node_modules/.bin/mocha`
 so to enable this do the following:
 
-1. Open your `~/.bashrc` in your editor
-1. Add the line `export PATH="./node_modules/.bin:$PATH"` to your `~/.bashrc` file
+1. Open your `~/.bash-profile` in your editor
+1. Add the line `export PATH="./node_modules/.bin:$PATH"` to your `~/.bash-profile` file
 1. Close and re-open all of your shells for this to take affect
 
 For more information on `$PATH` and how this works, see the


### PR DESCRIPTION
Mac OSX runs a login shell by default for each new terminal window, calling .bash_profile instead of .bashrc.  See http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html